### PR TITLE
Run forgotten CI tests + preparatory work for env var fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,10 @@ jobs:
       - run: &install_dependencies
           name: Install dependencies
           command: |
-            apk add --no-cache --no-progress make python3==3.7.5-r1 py-pip git
+            # dependencies for building the image
+            apk add --no-cache --no-progress make
+            # dependencies for testing pip dependencies (python must support typing)
+            apk add --no-cache --no-progress python3==3.7.5-r1 py-pip git
             python3 -m venv venv
             source venv/bin/activate
             pip3 install -r testing/requirements.txt
@@ -47,7 +50,7 @@ jobs:
             name: Run tests
             command: |
               make test_timeout
-              make test_dependencies_pip  TEST_IMAGE_DOCKER_MOUNT_OPTION="--volumes-from=aux"
+              make test_dependencies_pip  IMAGE_TEST_DOCKER_MOUNT_OPTION="--volumes-from=aux"
             no_output_timeout: 15m
 
       - run:

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,11 @@ DOCKERFILE?=targets/Dockerfile.python36-jupyter-pytorch-tensorflow-jupyterlab
 
 # Shortcuts:
 DOCKER_RUN?=docker run --env PLATFORMAPI_SERVICE_HOST=test --tty --rm
-ASSERT_COMMAND_FAILS=&& { echo "failure!"; exit 1; } || { echo "success!"; }
+ASSERT_COMMAND_FAILS=&& { echo -e 'Failure!\n'; exit 1; } || { echo -e 'Success!\n'; }
+ASSERT_COMMAND_SUCCEEDS=&& echo -e 'Success!\n'
 
 # Testing settings:
-TEST_IMAGE_DOCKER_MOUNT_OPTION?=--volume=`pwd`/testing:/testing
+IMAGE_TEST_DOCKER_MOUNT_OPTION?=--volume=`pwd`/testing:/testing
 
 
 .PHONY: image
@@ -26,11 +27,11 @@ test_dependencies_pip:
 	# Note: `--network=host` is used for the Internet access (to use `pip install ...`)
 	# however this prevents SSH to start (port 22 is already bind).
 	# see https://github.com/neuromation/template-base-image/issues/21
-	$(DOCKER_RUN) $(TEST_IMAGE_DOCKER_MOUNT_OPTION) --network=host --workdir=/testing $(IMAGE_NAME) python ./run_tests.py
+	$(DOCKER_RUN) $(IMAGE_TEST_DOCKER_MOUNT_OPTION) --network=host --workdir=/testing $(IMAGE_NAME) python ./run_tests.py
 
 .PHONY: test_timeout
 test_timeout:
 	# job exits within the timeout 3 sec (ok):
-	$(DOCKER_RUN) -e JOB_TIMEOUT=3 $(IMAGE_NAME) sleep 1 && echo "success!"
+	$(DOCKER_RUN) -e JOB_TIMEOUT=3 $(IMAGE_NAME) sleep 1  $(ASSERT_COMMAND_SUCCEEDS)
 	# job exits within the timeout sec (exit code 124):
-	$(DOCKER_RUN) -e JOB_TIMEOUT=3 $(IMAGE_NAME) sleep 10 $(ASSERT_COMMAND_FAILS)
+	$(DOCKER_RUN) -e JOB_TIMEOUT=3 $(IMAGE_NAME) sleep 10  $(ASSERT_COMMAND_FAILS)


### PR DESCRIPTION
1. Major: `make timeout` was mistakenly excluded from CI
2. Minor: preparatory work for PR https://github.com/neuromation/template-base-image/pull/33/ (to make it smaller)
