### PR TITLE
Improve timeout tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,12 @@ test_dependencies_pip:
 
 .PHONY: test_timeout
 test_timeout:
-	# job exits within the timeout 3 sec (ok):
-	$(DOCKER_RUN) -e JOB_TIMEOUT=3 $(IMAGE_NAME) sleep 1  $(ASSERT_COMMAND_SUCCEEDS)
-	# job exits within the timeout sec (exit code 124):
-	$(DOCKER_RUN) -e JOB_TIMEOUT=3 $(IMAGE_NAME) sleep 10  $(ASSERT_COMMAND_FAILS)
+	# job succeeds within the timeout 1 sec:
+	$(DOCKER_RUN) -e JOB_TIMEOUT=1 $(IMAGE_NAME) sleep 0.1  $(ASSERT_COMMAND_SUCCEEDS)
+	# job fails within the timeout 1 sec and exit status remains
+	$(DOCKER_RUN) -e JOB_TIMEOUT=1 $(IMAGE_NAME) bash -c 'exit 123' ; [ $$? -eq 123 ] $(ASSERT_COMMAND_SUCCEEDS)
+	# job exits within the timeout 1 sec (exit code 124):
+	$(DOCKER_RUN) -e JOB_TIMEOUT=1 $(IMAGE_NAME) sleep 10  $(ASSERT_COMMAND_FAILS)
 
 
 .PHONY: cleanup_test_ssh


### PR DESCRIPTION
some test improvements:
1. timeout tests will take shorter time to work
2. add a timeout test that checks that exit code remains if a command failed within timeout