### PR TITLE
Add OOM guard

### DIFF
--- a/files/root/oom_guard.sh
+++ b/files/root/oom_guard.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# This script ensures only the process with PID = 1
+# would have minimal oom_score_adj value
+# That means it will only be killed by oom_killer at the last resort
+
+for pid in $(ps x | awk 'NR>1 {print $1}' | xargs)
+do
+  if [ "$pid" != "1" ]
+  then
+    echo 1000 > /proc/"$pid"/oom_score_adj
+  fi
+done

--- a/targets/python37-jupyter-pytorch-tensorflow-jupyterlab/Dockerfile
+++ b/targets/python37-jupyter-pytorch-tensorflow-jupyterlab/Dockerfile
@@ -31,6 +31,7 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
         apt-utils \
         build-essential \
         ca-certificates \
+        cron \
         curl \
         git \
         libssl-dev \
@@ -190,6 +191,14 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
 # So we fix installation to the version Apr 21, 2020
     $PIP_INSTALL --global-option="--cpp_ext" --global-option="--cuda_ext" \
       git+https://github.com/NVIDIA/apex@2ec84ebdca59278eaf15e8ddf32476d9d6d8b904
+
+# ==================================================================
+# OOM guard
+# Adds a script to tune oom_killer behavior and puts it into the crontab
+# ==================================================================
+
+COPY files/root/oom_guard.sh /root/oom_guard.sh
+RUN crontab -l 2>/dev/null | { cat; echo '* * * * * /root/oom_guard.sh'; } | crontab
 
 # ==================================================================
 # Documentation notebook


### PR DESCRIPTION
Adds a script `/root/oom_guard.sh` and a corresponding crontab entry to run it every minute.

The script sets `oom_score_adj` to 1000 for all processes except pid=1. This ensures all other procs are get OOM-killed first.