### PR TITLE
IT-108: Split the conda mega-layer into per-env layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,10 @@ COPY requirements/tf.txt /tmp/requirements/tf.txt
 # ==================================================================
 # Miniconda
 # ------------------------------------------------------------------
+# Split into separate RUN layers (one per conda env + code-server) so the
+# largest blob stays a few GB instead of a single ~8 GB layer, which chokes
+# registry/ingress on push/pull (IT-104). conda activation does not persist
+# across RUN instructions, so each layer re-sources conda.sh.
 RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py311_25.1.1-2-Linux-x86_64.sh -O ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh && \
@@ -86,31 +90,30 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py311_25.1.1-2-L
     $PIP_INSTALL pip pipx && \
     python3 -m pipx ensurepath && \
     $PIP_INSTALL -r /tmp/requirements/python.txt --extra-index-url https://download.pytorch.org/whl && \
-    conda install --channel conda-forge nb_conda_kernels==2.5.1 && \
+    conda install --channel conda-forge nb_conda_kernels==2.5.1
 # ==================================================================
 # Create a Separate Conda Environment for TORCH
 # ------------------------------------------------------------------
+RUN . /opt/conda/etc/profile.d/conda.sh && \
+    PIP_INSTALL="python -m pip --no-cache-dir install --upgrade" && \
     conda create -y -n torch python=3.11 && \
     conda activate torch && \
     $PIP_INSTALL -r /tmp/requirements/python.txt && \
-    $PIP_INSTALL -r /tmp/requirements/torch.txt --extra-index-url https://download.pytorch.org/whl && \
-    conda deactivate && \
+    $PIP_INSTALL -r /tmp/requirements/torch.txt --extra-index-url https://download.pytorch.org/whl
 # ==================================================================
 # Create a Separate Conda Environment for TENSORFLOW
 # ------------------------------------------------------------------
+RUN . /opt/conda/etc/profile.d/conda.sh && \
+    PIP_INSTALL="python -m pip --no-cache-dir install --upgrade" && \
     conda create -y -n tf python=3.11 && \
     conda activate tf && \
     $PIP_INSTALL -r /tmp/requirements/python.txt && \
     $PIP_INSTALL -r /tmp/requirements/tf.txt && \
-    conda deactivate && \
-# ================================================================== \
-# Remove the requirements folder \
-# ------------------------------------------------------------------ \
-    rm -r /tmp/requirements && \
+    rm -r /tmp/requirements
 # ==================================================================
 # VSCode server
 # ------------------------------------------------------------------
-    wget -q https://github.com/cdr/code-server/releases/download/v3.11.1/code-server_3.11.1_amd64.deb && \
+RUN wget -q https://github.com/cdr/code-server/releases/download/v3.11.1/code-server_3.11.1_amd64.deb && \
     dpkg -i code-server_3.11.1_amd64.deb && \
     rm code-server_3.11.1_amd64.deb
 # ==================================================================


### PR DESCRIPTION
## Summary

`ghcr.io/neuro-inc/base` has a single ~8 GB layer — the Miniconda install plus the `torch` and `tf` conda envs were all built in one `RUN`, so ~76% of the image sits in one blob. A blob that large is exactly what chokes registry ingress on push/pull ([IT-104](https://apolocloud.atlassian.net/browse/IT-104)): any per-request size/time limit in the path breaks on this one layer, and derived images (everything built from this base) inherit the fragility.

This splits the single `RUN` into one `RUN` per conda env (base, torch, tf) plus a separate one for code-server. The largest layer drops from ~8 GB to ~2–3 GB, and independent layers pull in parallel.

The filesystem result is identical — only the layer boundaries change. Since conda activation does not persist across `RUN` instructions, each new layer re-sources `/opt/conda/etc/profile.d/conda.sh` before `conda activate`; every install target (base ← python.txt + nb_conda_kernels, torch ← python.txt + torch.txt, tf ← python.txt + tf.txt) is preserved verbatim.

Only the full `Dockerfile` is affected; `Dockerfile.minimal` has no torch/tf envs and is unchanged.

## Test plan

- Verified locally (apple `container`, aarch64 miniconda) that the cross-`RUN` conda pattern works: a `RUN` that installs Miniconda, then a *separate* `RUN` that does `conda create -n torch && conda activate torch && pip install …`, then another for `tf` — each fresh shell re-sources conda.sh and installs into the right env (`/opt/conda/envs/torch/bin/python`, `/opt/conda/envs/tf/bin/python`). This is the one behavioral risk of the split and it holds.
- Full build of all four matrix variants (devel/runtime × Dockerfile/minimal) and the GPU dependency tests are exercised by CI here.

Follow-up: dependency version bumps are tracked separately in IT-107.

[IT-104]: https://apolocloud.atlassian.net/browse/IT-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ