### PR TITLE
IT-107: Bump apolo-all to 26.1.0 in the base image

### DIFF
--- a/requirements/pipx.minimal.txt
+++ b/requirements/pipx.minimal.txt
@@ -1,1 +1,1 @@
-apolo-all==25.1.0
+apolo-all==26.1.0

--- a/requirements/pipx.txt
+++ b/requirements/pipx.txt
@@ -1,2 +1,2 @@
-apolo-all==25.1.0
+apolo-all==26.1.0
 awscli==1.38.14


### PR DESCRIPTION
## Summary

The base image pins `apolo-all==25.1.0` (requirements/pipx.txt, pipx.minimal.txt). That version imports `AWSCloudProvider` from `neuro_config_client`, a name newer `neuro-config-client` no longer exposes — so `apolo config show` and `apolo-flow --version` inside the image fail with `ImportError: cannot import name 'AWSCloudProvider' from 'neuro_config_client'`. This surfaced in the base-image CI dependency test once it could actually run (see IT-115 / #652); before that, the GPU test never scheduled, so the rot was masked.

Bump to `apolo-all==26.1.0` (the current release), whose code no longer references the removed name.

Scope note: this is the dependency that's actually broken. The ML frameworks at HEAD are already current (Miniconda py311_25.1.1, torch 2.5.1+cu124, tf 2.18.0), so no framework bump is included here — that would be a coordinated CUDA-compat change and can't be GPU-validated while CI runs on CPU (IT-115). awscli is left at 1.38.14 (bumping it pulls a botocore that conflicts with apolo-all's aiobotocore).

## Test plan

Verified in a clean venv (matching the base image's pipx isolation) that `apolo-all==26.1.0` resolves the import: `apolo --version` → 26.1.0, `apolo-extras --version` → 25.9.0, `apolo-flow --version` → 24.12.1, and `apolo config show` runs — all with no `AWSCloudProvider` ImportError (neuro-config-client 25.12.0, the name absent, but 26.1.0 no longer imports it).

Together with #652 (CPU test preset) this greens the base-image CI; #651 (layer split) then passes on rebase.