### PR TITLE
IT-115: Skip nvidia-smi in the minimal test on CPU

### DIFF
--- a/files/testing/dependencies.minimal.sh
+++ b/files/testing/dependencies.minimal.sh
@@ -27,4 +27,8 @@ apolo-extras --version
 apolo-flow --version
 apolo config show
 
-nvidia-smi
+if command -v nvidia-smi >/dev/null 2>&1; then
+    nvidia-smi
+else
+    echo "nvidia-smi not available (no GPU), skipping"
+fi


### PR DESCRIPTION
## Summary

Follow-up to #652 (running the base-image dependency test on `cpu-large`). `files/testing/dependencies.minimal.sh` called `nvidia-smi` unconditionally; on a CPU node that's `command not found`, and with `set -e` it aborts the whole test (`make test_dependencies` → Error 127). Guard it: run `nvidia-smi` when present, print a skip note otherwise.

The full `dependencies.sh` has no bare `nvidia-smi` — its GPU checks go through `gpu_tensorflow.py` / `gpu_pytorch.py`, which #652 already made GPU-conditional. This was the remaining CPU-hard command missed in #652.

## Test plan

`bash -n` clean. The guard is a standard `command -v` check; on CPU it prints "nvidia-smi not available (no GPU), skipping" and continues, on GPU it runs nvidia-smi as before. CI here exercises both variants on `cpu-large` end-to-end.