### PR TITLE
IT-116: Pin setuptools to keep pkg_resources for tensorboard

### DIFF
--- a/requirements/python.txt
+++ b/requirements/python.txt
@@ -9,6 +9,7 @@ pandas==2.2.3
 Pillow==9.4.0
 scikit-learn==1.5.2
 scipy==1.14.1
+setuptools==81.0.0
 tensorboardX==2.6.2.2
 tqdm==4.66.5
 typing==3.7.4.3


### PR DESCRIPTION
## Problem

Fresh builds of the full base image fail the tf-env dependency test:

```
$ tensorboard --version
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

The published `base:latest` works fine, so this only surfaces on a rebuild — classic dependency rot.

## Root cause

1. `tensorboard --version` fails → `ModuleNotFoundError: No module named 'pkg_resources'`.
2. `pkg_resources` is missing → **setuptools 82.0.0 removed the bundled `pkg_resources`**; a fresh build installs setuptools 83.
3. The build gets setuptools 83 → setuptools is **not pinned**, so conda/pip take the latest at build time (the old image was built when the latest was 75.8.0).
4. That breaks tensorboard → tensorboard 2.18.0 does `import pkg_resources` at startup.
5. Root cause → unpinned setuptools + tensorboard 2.18's hard dependency on `pkg_resources`; the build's success depends on the date it runs.

Exact cutover confirmed in a clean venv:

| setuptools | pkg_resources present |
|---|---|
| 75.8.0 / 80.9.0 / 81.0.0 | yes |
| 82.0.0 / 83.0.0 | **no** |

## Fix

Pin `setuptools==81.0.0` (last release that still ships `pkg_resources`) in `requirements/python.txt`, which is installed into all three envs (base, torch, tf). This restores deterministic, reproducible builds.

This is the stopgap for the immediate rot; upgrading tensorflow/tensorboard to a line that no longer imports `pkg_resources` is the broader deps refresh tracked separately under IT-116.