### PR TITLE
build(deps): bump mlflow[extras] from 3.14.0 to 3.15.0

### DIFF
--- a/requirements/python.txt
+++ b/requirements/python.txt
@@ -3,7 +3,7 @@ future==1.0.0
 ipywidgets==8.1.8
 jupyterlab==4.6.2
 matplotlib==3.11.1
-mlflow[extras]==3.14.0
+mlflow[extras]==3.15.0
 opencv-python-headless==5.0.0.93
 packaging==25.0
 pandas==2.3.3


### PR DESCRIPTION
Bumps `mlflow[extras]` from 3.14.0 to 3.15.0.

Closes Dependabot alert [#185](https://github.com/neuro-inc/apolo-base-image/security/dependabot/185) — GHSA-7gwp-5pfp-969j, **critical, CVSS 9.3**: unauthenticated full-read SSRF in webhook delivery (`_validate_webhook_url` bypassed via unvalidated HTTP redirects and DNS rebinding).

Same one-line change as Dependabot's #668, opened manually because **#668 can never go green**: its CI is triggered by `dependabot[bot]`, and the `Login DockerHub` step fails with `Username and password required` — the `DOCKER_USERNAME` / `DOCKER_PASSWORD` entries in this repo's **Dependabot** secrets store do not carry usable values (run [32081900045](https://github.com/neuro-inc/apolo-base-image/actions/runs/32081900045), step 7). The step before it, `Configure environment`, passes on `secrets.CLIENT_TEST_E2E_USER_NAME`, so the Dependabot store is reachable — it is these two entries specifically. This PR runs under a human actor, so it gets the org Actions secrets and the same build can actually complete.

#668 becomes obsolete once this merges. The underlying secret problem still blocks every other bot PR in this repo and is tracked separately.
