### PR TITLE
build(deps): bump awscli from 1.44.78 to 1.45.28

### DIFF
--- a/requirements/pipx.txt
+++ b/requirements/pipx.txt
@@ -1,2 +1,2 @@
 apolo-all==26.1.0
-awscli==1.44.78
+awscli==1.45.28


### PR DESCRIPTION
Bumps `awscli` from 1.44.78 to 1.45.28.

Closes Dependabot alert [#184](https://github.com/neuro-inc/apolo-base-image/security/dependabot/184) — GHSA-hqvf-45jj-mccq (medium): SSH host key verification disabled in the EMR helper commands.

Opened manually rather than merging Dependabot's #660, because that PR is no longer just a dependency bump — @YevheniiSemendiak pushed a `Rework actions` commit onto its branch (splits `ci.yaml` into a reusable `test.yaml`, drops the two automerge workflows). Merging #660 would land that rework, and `@dependabot rebase` on it would destroy the commit. Left untouched, decision pending.

Note the rework does **not** fix the Dependabot-runs problem: `test.yaml` keeps the `Login DockerHub` step on PR builds, so a bot-triggered run would still fail there.
